### PR TITLE
Issue #42 Fix

### DIFF
--- a/ghettoVCB.sh
+++ b/ghettoVCB.sh
@@ -823,7 +823,7 @@ ghettoVCB() {
         IFS="${IFS2}"
     fi
 
-    for VM_NAME in $(cat "${VM_INPUT}" | grep -v "#" | sed '/^$/d' | sed -e 's/^[[:blank:]]*//;s/[[:blank:]]*$//'); do
+    for VM_NAME in $(cat "${VM_INPUT}" | grep -v "^#" | sed '/^$/d' | sed -e 's/^[[:blank:]]*//;s/[[:blank:]]*$//'); do
         IGNORE_VM=0
         if [[ "${EXCLUDE_SOME_VMS}" -eq 1 ]] ; then
             grep -E "^${VM_NAME}" "${VM_EXCLUSION_FILE}" > /dev/null 2>&1


### PR DESCRIPTION
Applied the fix described in issue #42.  The program will not error out
when the VM name has a # in it.  The program will continue to skip VMs
with a # before the name.